### PR TITLE
fix registry bug

### DIFF
--- a/+sig/Registry.m
+++ b/+sig/Registry.m
@@ -8,7 +8,7 @@ classdef Registry < StructRef
   end
   
   methods
-    function obj = SignalsExp(clockFun)
+    function obj = Registry(clockFun)
       if nargin < 1
         obj.ClockFun = @GetSecs;
       else


### PR DESCRIPTION
Constructor was improperly named, prevents clockFun from getting properly assigned, which prevents any times from being properly logged. This just renames the constructor. 