### PR TITLE
Output to particular audio devices by named subsasgn

### DIFF
--- a/+audstream/Registry.m
+++ b/+audstream/Registry.m
@@ -33,6 +33,7 @@ classdef Registry < StructRef
       d = this.Devices(name);
       this.Handles = ...
         [this.Handles audstream.fromSignal(value, d.DefaultSampleRate, 2, d.NrOutputChannels, d.DeviceIndex)];
+      this.EntryNames = {}; % Clear entry names in order to keep adding new handles
     end
   end
   

--- a/+vis/grating.m
+++ b/+vis/grating.m
@@ -18,6 +18,7 @@ elem.sigma = [10 10];
 elem.spatialFreq = 1/15;
 elem.phase = 0;
 elem.orientation = 0;
+elem.colour = [1 1 1];
 elem.contrast = 1;
 elem.show = false;
 
@@ -42,8 +43,8 @@ end
 gratingLayer.blending = 'destination';
 l = 0.5 - 0.5*newelem.contrast;
 h = 0.5 + 0.5*newelem.contrast;
-gratingLayer.minColour = l.*[1 1 1 0];
-gratingLayer.maxColour = [h.*ones(1, 3) 1];
+gratingLayer.minColour = l.*[newelem.colour 0];
+gratingLayer.maxColour = h.*[newelem.colour 1];
 gratingLayer.show = newelem.show;
 
 %% make a stencil layer using a window of the specified type

--- a/util/StructRef.m
+++ b/util/StructRef.m
@@ -28,7 +28,12 @@ classdef StructRef < handle
     end
     
     function [varargout] = subsref(this, s)
-      [varargout{1:nargout}] = subsref(this.Entries, s);
+      if any(strcmp(this.Reserved, s(1).subs))
+        % If subscripted reference is a reserved property, use builtin
+        [varargout{1:nargout}] = builtin('subsref', this, s);
+      else % Otherwise return entry value
+        [varargout{1:nargout}] = subsref(this.Entries, s);
+      end
     end
   end
 

--- a/util/toStr.m
+++ b/util/toStr.m
@@ -29,7 +29,7 @@ elseif islogical(v)
     s = num2str(v);
   end
 elseif isstruct(v)
-  warning('todo: implement toStr on structs');
+  warning('toStr:isstruct:Unfinished', 'todo: implement toStr on structs');
   s = ['<' strJoin(fieldnames(v), ',') '>'];
 elseif isa(v, 'function_handle')
   s = func2str(v);


### PR DESCRIPTION
Changes to audstream.Registry so that object holds audio devices structure in containers map, whose details can be returned with a subsref to the device name (e.g. audio.default returns the device info for device name 'default').

Outputting audio samples to a named device is achieved by changes to entryAdded method.

Additionally, the toStr warning can now be suppressed and vis.grating now has a colour parameter.