### PR TITLE
Can now map value of one signal to another

### DIFF
--- a/+sig/+node/Signal.m
+++ b/+sig/+node/Signal.m
@@ -55,14 +55,15 @@ classdef Signal < sig.Signal & handle
       f = applyTransferFun(what, when, 'sig.transfer.keepWhen', [], '%s.keepWhen(%s)');
     end
     
-    function m = map(this, f, varargin)
-      if numel(varargin) > 0
-        formatSpec = varargin{1};
-      else
-        formatSpec = sprintf('%%s.map(%s)', toStr(f));
-      end
-      if ~isa(f, 'function_handle') % always map to a value
-        f = fun.always(f);
+    function m = map(this, f, formatSpec)
+      if nargin < 3; formatSpec = sprintf('%%s.map(%s)', toStr(f)); end
+      if isa(f, 'sig.Signal')
+        m = this.map(true).then(f);
+        m.Node.DisplayInputs = this.Node;
+        m.Node.FormatSpec = formatSpec;
+        return
+      elseif ~isa(f, 'function_handle')
+        f = fun.always(f); % always map to a value
       end
       m = applyTransferFun(this, 'sig.transfer.map', f, formatSpec);
     end

--- a/util/toStr.m
+++ b/util/toStr.m
@@ -9,6 +9,8 @@ elseif isempty(v)
 elseif isobject(v)
   if any(strcmp(methods(v), 'str'))
     s = str(v);
+  elseif any(strcmp(properties(v), 'Name'))
+    s = v.Name;
   else
     s = class(v);
   end


### PR DESCRIPTION
Can now map value of one signal when another updates, similar to mapping a constant. 

Example:
```
a = b.map(c); % NEW: whenever b updates, a takes value of c, regardless of b's value

% c.f.
a = b.map(true); % whenever b updates, a takes value of true, regardless of b's value
a = c.at(b); % whenever b updates AND evaluates true, a takes value of c
```
This is implemented as a sort of syntactic sugar for `a = b.map(true).then(c)`.  Frequently the value of `b` is not important, only the time at which it updates.