### PR TITLE
Added mapn to multiple output Signals

### DIFF
--- a/+sig/+node/Signal.m
+++ b/+sig/+node/Signal.m
@@ -71,7 +71,7 @@ classdef Signal < sig.Signal & handle
       m = mapn(sig1, sig2, f, varargin{:});
     end
     
-    function m = mapn(varargin)
+    function varargout = mapn(varargin)
       % destructure varargin
       if isa(varargin{end}, 'function_handle')
         [sigs{1:nargin-1}, f] = varargin{:};
@@ -79,7 +79,10 @@ classdef Signal < sig.Signal & handle
       else
         [sigs{1:nargin-2}, f, formatSpec] = varargin{:};
       end
-      m = applyTransferFun(sigs{:}, 'sig.transfer.mapn', f, formatSpec);
+      varargout = cell(1,nargout);
+      for i = 1:nargout
+        [varargout{i}] = applyTransferFun(sigs{:}, 'sig.transfer.mapn', {f,i}, formatSpec);
+      end
     end
     
     function sc = scan(varargin)

--- a/+sig/+transfer/mapn.m
+++ b/+sig/+transfer/mapn.m
@@ -2,6 +2,7 @@ function [val, valset] = mapn(net, inputs, node, f)
 %XSIG.TRANSFER.MAPN Summary of this function goes here
 %   Detailed explanation goes here
 
+[f, outnum] = f{:};
 n = numel(inputs);
 inpvals = cell(n, 1);
 wvset = false(n, 1);
@@ -24,7 +25,9 @@ end
 if any(wvset)
   % canonical line: call map function with latest inputs. new output is
   % result from map
-  val = f(inpvals{:});
+  out = cell(1,outnum);
+  [out{:}] = f(inpvals{:});
+  val = out{end};
   valset = true;
 else % no inputs have a working value -> no output
   val = [];

--- a/tests/mapn_test.asv
+++ b/tests/mapn_test.asv
@@ -1,0 +1,22 @@
+% mapn test
+%  prerequisites:
+net = sig.Net;
+x = net.origin('x');
+y = net.origin('y');
+
+%% Test for mapn
+% Test mapping multiple input signals to multiple output signals
+[X, Y] = x.mapn(y, @meshgrid);
+
+% Test with these inputs
+xx = 1:5; yy = 5:10;
+[expectedX, expectedY] = meshgrid(xx, yy);
+
+x.post(xx); y.post(yy);
+actualX = X.Node.CurrValue;
+actualY = Y.Node.CurrValue;
+
+% Verify outputs equal to expected
+isEqualX = isequal(expectedX, actualX);
+isEqualY = isequal(expectedY, actualY);
+assert(isEqualX && isEqualY, 'Failed to assign expected outputs')

--- a/tests/mapn_test.m
+++ b/tests/mapn_test.m
@@ -1,0 +1,22 @@
+% mapn test
+%  prerequisites:
+net = sig.Net;
+x = net.origin('x');
+y = net.origin('y');
+
+%% Test for mapn
+% Test mapping multiple input signals to multiple output signals
+[X, Y] = x.mapn(y, @meshgrid);
+
+% Test with these inputs
+xx = 1:5; yy = 5:10;
+[expectedX, expectedY] = meshgrid(xx, yy);
+
+x.post(xx); y.post(yy);
+actualX = X.Node.CurrValue;
+actualY = Y.Node.CurrValue;
+
+% Verify Signals implementation yields equal output values
+isEqualX = isequal(expectedX, actualX);
+isEqualY = isequal(expectedY, actualY);
+assert(isEqualX && isEqualY, 'Failed to assign expected outputs')


### PR DESCRIPTION
Made a change so that `mapn` can map a variable number of output args to an equal number of Signals:

```
[Y, I] = X.mapn([], 2, @max);
X.post(magic(3))
>> Y.Node.CurrValue

ans =

     8
     7
     9

>> I.Node.CurrValue

ans =

     1
     3
     2
```

Previously it was not possible to assign any more than the first output argument with `mapn`.  Currently this feature is only implemented with `mapn`, not `map` or `map2`.  It is not possible to assign more than one output with size, i.e. `[M,N] = size(X)`.  This change could easily be implemented by modifying the `size` method here:
https://github.com/dendritic/signals/blob/c2cf2854491525905ed9f21e0d708b451bfce988/%2Bsig/%2Bnode/Signal.m#L366-L372

This is the only overloaded method whose builtin returns more than one output.

The format spec does not currently reflect the output argument number.  Perhaps this could be done with square brackets, e.g.
```
>> I.Name

ans =

    'mapn(X, [], 2, @max)[2]'
```

What are your thoughts?